### PR TITLE
Add 7.4.0 to Build Matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       GREP_TIMEOUT: 60
     strategy:
       matrix:
-        COURIER_VERSION: ["6.0.0", "6.2.2", "6.4.0", "7.0.0", "7.2.0"]
+        COURIER_VERSION: ["6.0.0", "6.2.2", "6.4.0", "7.0.0", "7.2.0", "7.4.0"]
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Add courier 7.4.0 which is the officially supported version for RapidPro 7.4.2